### PR TITLE
[CON-15] 스플래시 화면 작성

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         <activity
             android:name=".screen.feature.intro.IntroActivity"
             android:exported="true"
-            android:screenOrientation="portrait">
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.TeamOne.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/presentation/src/main/java/com/connectcrew/presentation/screen/feature/intro/IntroActivity.kt
+++ b/presentation/src/main/java/com/connectcrew/presentation/screen/feature/intro/IntroActivity.kt
@@ -1,5 +1,7 @@
 package com.connectcrew.presentation.screen.feature.intro
 
+import android.os.Bundle
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import com.connectcrew.presentation.R
@@ -10,8 +12,13 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro) {
 
-    private val navController : NavController
+    private val navController: NavController
         get() = findNavController(R.id.nav_intro)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+        super.onCreate(savedInstanceState)
+    }
 
     override fun onSupportNavigateUp(): Boolean = navController.navigateUp()
 }

--- a/presentation/src/main/java/com/connectcrew/presentation/screen/feature/intro/IntroFragment.kt
+++ b/presentation/src/main/java/com/connectcrew/presentation/screen/feature/intro/IntroFragment.kt
@@ -2,6 +2,9 @@ package com.connectcrew.presentation.screen.feature.intro
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.connectcrew.presentation.R
@@ -21,6 +24,7 @@ class IntroFragment : BaseFragment<FragmentIntroBinding>(R.layout.fragment_intro
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        hideSystemUi()
         initObserver()
     }
 
@@ -54,5 +58,23 @@ class IntroFragment : BaseFragment<FragmentIntroBinding>(R.layout.fragment_intro
                 }
             }
         }
+    }
+
+    private fun hideSystemUi() {
+        WindowCompat.setDecorFitsSystemWindows(requireActivity().window, false)
+        WindowInsetsControllerCompat(requireActivity().window, dataBinding.root).let { controller ->
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+    }
+
+    private fun showSystemUi() {
+        WindowCompat.setDecorFitsSystemWindows(requireActivity().window, true)
+        WindowInsetsControllerCompat(requireActivity().window, dataBinding.root).show(WindowInsetsCompat.Type.systemBars())
+    }
+
+    override fun onDestroyView() {
+        showSystemUi()
+        super.onDestroyView()
     }
 }

--- a/presentation/src/main/java/com/connectcrew/presentation/screen/feature/intro/IntroViewModel.kt
+++ b/presentation/src/main/java/com/connectcrew/presentation/screen/feature/intro/IntroViewModel.kt
@@ -13,6 +13,7 @@ import com.connectcrew.presentation.screen.base.BaseViewModel
 import com.connectcrew.presentation.util.event.EventFlow
 import com.connectcrew.presentation.util.event.MutableEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -40,6 +41,7 @@ class IntroViewModel @Inject constructor(
                         signInUseCase(SignInUseCase.Params(tokenInfo.accessToken, tokenInfo.socialType))
                             .asResult()
                             .collect { apiResult ->
+                                delay(1000L)
                                 when (apiResult) {
                                     is ApiResult.Loading -> return@collect
                                     is ApiResult.Success -> _navigateToHome.emit(Unit)
@@ -55,6 +57,7 @@ class IntroViewModel @Inject constructor(
                                 }
                             }
                     } else {
+                        delay(1000L)
                         _navigateToSignIn.emit(Unit)
                     }
                 }

--- a/presentation/src/main/res/layout/fragment_intro.xml
+++ b/presentation/src/main/res/layout/fragment_intro.xml
@@ -6,7 +6,31 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/color_primary"
         tools:context=".screen.feature.intro.IntroFragment">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/iv_splash"
+            android:layout_width="237dp"
+            android:layout_height="237dp"
+            android:layout_marginTop="240dp"
+            android:tint="@android:color/white"
+            android:src="@drawable/ic_team_one_logo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_splash"
+            style="@style/Widget.TeamOne.TextView.LargeTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="25dp"
+            android:text="@string/intro_title"
+            android:textColor="@android:color/white"
+            app:layout_constraintEnd_toEndOf="@id/iv_splash"
+            app:layout_constraintStart_toStartOf="@id/iv_splash"
+            app:layout_constraintTop_toBottomOf="@id/iv_splash" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -52,4 +52,7 @@
     <string name="onboarding_sign_up_complete">회원가입 완료!</string>
     <string name="onboarding_sign_up_complete_description">지금 당장\n빛나는 아이디어를 함께할\n팀원들을 모집해보세요!</string>
     <string name="onboarding_start">시작하기</string>
+
+    <!-- Intro -->
+    <string name="intro_title">TEAM no.1</string>
 </resources>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -23,5 +23,15 @@
         <item name="materialAlertDialogTheme">@style/TeamOneAlertDialogTheme</item>
     </style>
 
-    <style name="Theme.TeamOne" parent="Base.Theme.TeamOne" />
+    <style name="Theme.TeamOne" parent="Base.Theme.TeamOne"/>
+
+    <!-- Splash Screen -->
+    <style name="Theme.TeamOne.Splash" parent="Theme.SplashScreen">
+        <item name="postSplashScreenTheme">@style/Theme.TeamOne</item>
+        <item name="windowSplashScreenBackground">@color/color_primary</item>
+        <item name="windowSplashScreenAnimatedIcon">@color/color_primary</item>
+        <item name="android:statusBarColor">@color/color_primary</item>
+        <item name="android:navigationBarColor">@color/color_primary</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 작업내용
[CON-15] 스플래시 화면 작성
- Andriod 12 이상부터 사용되는 기본 스플래시 스크린은 배경색만 통일하게 해두었어요.
- 스플래시 화면을 추가했어요.
- 스플래시 로고를 추가했어요.

## 스크린샷
| before | after |
:-:|:-:
<img src="" width="250"/>| <image src="https://github.com/Connect-Crew/TeamOne-AOS/assets/76645322/1029e2b3-119a-4ea1-b683-7c2a52e93367" width="250"/>

[CON-15]: https://hyeonjunkang.atlassian.net/browse/CON-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ